### PR TITLE
task: Write new tests and refactor old ones

### DIFF
--- a/mci/api/v1_0_0/user_handler.py
+++ b/mci/api/v1_0_0/user_handler.py
@@ -439,6 +439,7 @@ class UserHandler(object):
             matching_service_uri = config.get_matching_service_uri()
             new_user_json = json.dumps(new_user.as_dict, default=str)
             try:
+                import pdb; pdb.set_trace()
                 response = requests.post(matching_service_uri, data=new_user_json, timeout=5)
             except ConnectionError:
                 return {

--- a/mci/api/v1_0_0/user_handler.py
+++ b/mci/api/v1_0_0/user_handler.py
@@ -439,7 +439,6 @@ class UserHandler(object):
             matching_service_uri = config.get_matching_service_uri()
             new_user_json = json.dumps(new_user.as_dict, default=str)
             try:
-                import pdb; pdb.set_trace()
                 response = requests.post(matching_service_uri, data=new_user_json, timeout=5)
             except ConnectionError:
                 return {

--- a/tests/test_user_endpoints.py
+++ b/tests/test_user_endpoints.py
@@ -20,76 +20,84 @@ class TestMCIAPI(object):
         assert response.status_code == 404
         assert response.json['users'] == []
     
-    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_users_endpoint_populated(self, mocker, database, individual, test_client, json_headers):
-        '''
-        Tests that the users endpoint returns expected content when the database has Individual entries.
-        '''
-        self._post_new_individual(individual, test_client, json_headers)
+    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    # def test_users_endpoint_populated(self, mocker, database, individual, test_client, json_headers):
+    #     '''
+    #     Tests that the users endpoint returns expected content when the database has Individual entries.
+    #     '''
+    #     self._post_new_individual(individual, test_client, json_headers)
 
-        response = test_client.get('/users')
+    #     response = test_client.get('/users')
 
-        assert response.status_code == 200
-        assert isinstance(response.json['users'][0], dict)
-        assert 'mci_id' in response.json['users'][0].keys()
+    #     assert response.status_code == 200
+    #     assert isinstance(response.json['users'][0], dict)
+    #     assert 'mci_id' in response.json['users'][0].keys()
 
-    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_get_user_invalid(self, mocker, database, test_client):
-        '''
-        Tests that GETing an invalid user returns the correct error message.
-        '''
-        response = test_client.get('/users/123badid')
+    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    # def test_get_user_invalid(self, mocker, database, test_client):
+    #     '''
+    #     Tests that GETing an invalid user returns the correct error message.
+    #     '''
+    #     response = test_client.get('/users/123badid')
 
-        assert response.status_code == 410
-        assert response.json['message']
-        assert response.json['message'] == 'An individual with that ID does not exist in the MCI.'
+    #     assert response.status_code == 410
+    #     assert response.json['message']
+    #     assert response.json['message'] == 'An individual with that ID does not exist in the MCI.'
     
-    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_get_user_valid(self, mocker, database, individual, test_client, json_headers):
-        '''
-        Tests that GETing a valid user returns the JSON and 200 status code.
-        '''
-        new_individual = self._post_new_individual(individual, test_client, json_headers)
+    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    # def test_get_user_valid(self, mocker, database, individual, test_client, json_headers):
+    #     '''
+    #     Tests that GETing a valid user returns the JSON and 200 status code.
+    #     '''
+    #     new_individual = self._post_new_individual(individual, test_client, json_headers)
 
-        response = test_client.get('/users/{}'.format(new_individual['mci_id']))
+    #     response = test_client.get('/users/{}'.format(new_individual['mci_id']))
 
-        assert response.status_code == 200
-        assert response.json
+    #     assert response.status_code == 200
+    #     assert response.json
     
+    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    # def test_post_user_existing(self, mocker, database, individual, test_client, json_headers):
+    #     '''
+    #     Tests that POSTing an existing user returns a 200 with correct user information.
+    #     '''        
+    #     new_individual = self._post_new_individual(individual, test_client, json_headers)
+
+    #     with requests_mock.Mocker() as m:
+    #         m.post("http://mcimatchingservice_mci_1:8000/compute-match",
+    #               json={"mci_id": new_individual['mci_id'], "score": 10.0}, status_code=201)
+
+    #         response = test_client.post('/users', data=json.dumps(individual), headers=json_headers)
+
+    #     assert response.status_code == 200
+    #     assert response.json['first_name'] == individual['first_name']
+    #     assert response.json['last_name'] == individual['last_name']
+    #     assert response.json['mci_id'] == new_individual['mci_id']
+    #     assert response.json['match_probability'] == 10.0
+
+    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    # def test_post_user_bad_json(self, individual, test_client, json_headers):
+    #     with requests_mock.Mocker() as m:
+    #         m.post("http://mcimatchingservice_mci_1:8000/compute-match",
+    #               json={"mci_id": "", "score": ""}, status_code=201)
+
+    #         bad_json = {
+    #             'first_name': "Single",
+    #             'middle_name': "Quote",
+    #             'last_name': "Mistake",
+    #         }
+
+    #         response = test_client.post('/users', data=bad_json, headers=json_headers)
+    #         assert response.status_code == 400
+    #         assert response.json['error'] == 'Malformed or empty JSON object found in request body.'
+
     @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_post_user_existing(self, mocker, database, individual, test_client, json_headers):
-        '''
-        Tests that POSTing an existing user returns a 200 with correct user information.
-        '''        
-        new_individual = self._post_new_individual(individual, test_client, json_headers)
+    def test_post_user_matching_down(self, individual, test_client, json_headers):
+        import pdb; pdb.set_trace()
+        response = test_client.post('/users', data=json.dumps(individual), headers=json_headers)
 
-        with requests_mock.Mocker() as m:
-            m.post("http://mcimatchingservice_mci_1:8000/compute-match",
-                  json={"mci_id": new_individual['mci_id'], "score": 10.0}, status_code=201)
-
-            response = test_client.post('/users', data=json.dumps(individual), headers=json_headers)
-
-        assert response.status_code == 200
-        assert response.json['first_name'] == individual['first_name']
-        assert response.json['last_name'] == individual['last_name']
-        assert response.json['mci_id'] == new_individual['mci_id']
-        assert response.json['match_probability'] == 10.0
-
-    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_post_user_bad_json(self, individual, test_client, json_headers):
-        with requests_mock.Mocker() as m:
-            m.post("http://mcimatchingservice_mci_1:8000/compute-match",
-                  json={"mci_id": "", "score": ""}, status_code=201)
-
-            bad_json = {
-                'first_name': "Single",
-                'middle_name': "Quote",
-                'last_name': "Mistake",
-            }
-
-            response = test_client.post('/users', data=bad_json, headers=json_headers)
-            assert response.status_code == 400
-            assert response.json['error'] == 'Malformed or empty JSON object found in request body.'
+        assert response.status_code == 400
+        assert response.json['error'] == 'The matching service did not return a response.'
 
     @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
     def test_remove_pii_invalid_id(self, mocker, database, individual, test_client, json_headers):

--- a/tests/test_user_endpoints.py
+++ b/tests/test_user_endpoints.py
@@ -11,7 +11,7 @@ from mci_database.db.models import Individual
 
 class TestMCIAPI(object):
     @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_users_endpoint_empty(self, mocker, database, individual, test_client, json_headers):
+    def test_users_endpoint_empty(self, mocker, database, test_client):
         '''
         Tests that the users endpoint returns expected content when the database is empty.
         '''
@@ -20,80 +20,79 @@ class TestMCIAPI(object):
         assert response.status_code == 404
         assert response.json['users'] == []
     
-    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    # def test_users_endpoint_populated(self, mocker, database, individual, test_client, json_headers):
-    #     '''
-    #     Tests that the users endpoint returns expected content when the database has Individual entries.
-    #     '''
-    #     self._post_new_individual(individual, test_client, json_headers)
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_users_endpoint_populated(self, mocker, database, individual, test_client, json_headers):
+        '''
+        Tests that the users endpoint returns expected content when the database has Individual entries.
+        '''
+        self._post_new_individual(individual, test_client, json_headers)
 
-    #     response = test_client.get('/users')
+        response = test_client.get('/users')
 
-    #     assert response.status_code == 200
-    #     assert isinstance(response.json['users'][0], dict)
-    #     assert 'mci_id' in response.json['users'][0].keys()
-
-    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    # def test_get_user_invalid(self, mocker, database, test_client):
-    #     '''
-    #     Tests that GETing an invalid user returns the correct error message.
-    #     '''
-    #     response = test_client.get('/users/123badid')
-
-    #     assert response.status_code == 410
-    #     assert response.json['message']
-    #     assert response.json['message'] == 'An individual with that ID does not exist in the MCI.'
-    
-    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    # def test_get_user_valid(self, mocker, database, individual, test_client, json_headers):
-    #     '''
-    #     Tests that GETing a valid user returns the JSON and 200 status code.
-    #     '''
-    #     new_individual = self._post_new_individual(individual, test_client, json_headers)
-
-    #     response = test_client.get('/users/{}'.format(new_individual['mci_id']))
-
-    #     assert response.status_code == 200
-    #     assert response.json
-    
-    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    # def test_post_user_existing(self, mocker, database, individual, test_client, json_headers):
-    #     '''
-    #     Tests that POSTing an existing user returns a 200 with correct user information.
-    #     '''        
-    #     new_individual = self._post_new_individual(individual, test_client, json_headers)
-
-    #     with requests_mock.Mocker() as m:
-    #         m.post("http://mcimatchingservice_mci_1:8000/compute-match",
-    #               json={"mci_id": new_individual['mci_id'], "score": 10.0}, status_code=201)
-
-    #         response = test_client.post('/users', data=json.dumps(individual), headers=json_headers)
-
-    #     assert response.status_code == 200
-    #     assert response.json['first_name'] == individual['first_name']
-    #     assert response.json['last_name'] == individual['last_name']
-    #     assert response.json['mci_id'] == new_individual['mci_id']
-    #     assert response.json['match_probability'] == 10.0
-
-    # @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    # def test_post_user_bad_json(self, individual, test_client, json_headers):
-    #     with requests_mock.Mocker() as m:
-    #         m.post("http://mcimatchingservice_mci_1:8000/compute-match",
-    #               json={"mci_id": "", "score": ""}, status_code=201)
-
-    #         bad_json = {
-    #             'first_name': "Single",
-    #             'middle_name': "Quote",
-    #             'last_name': "Mistake",
-    #         }
-
-    #         response = test_client.post('/users', data=bad_json, headers=json_headers)
-    #         assert response.status_code == 400
-    #         assert response.json['error'] == 'Malformed or empty JSON object found in request body.'
+        assert response.status_code == 200
+        assert isinstance(response.json['users'][0], dict)
+        assert 'mci_id' in response.json['users'][0].keys()
 
     @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_post_user_matching_down(self, individual, test_client, json_headers):
-        import pdb; pdb.set_trace()
+    def test_get_user_invalid(self, mocker, database, test_client):
+        '''
+        Tests that GETing an invalid user returns the correct error message.
+        '''
+        response = test_client.get('/users/123badid')
+
+        assert response.status_code == 410
+        assert response.json['message']
+        assert response.json['message'] == 'An individual with that ID does not exist in the MCI.'
+    
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_get_user_valid(self, mocker, database, individual, test_client, json_headers):
+        '''
+        Tests that GETing a valid user returns the JSON and 200 status code.
+        '''
+        new_individual = self._post_new_individual(individual, test_client, json_headers)
+
+        response = test_client.get('/users/{}'.format(new_individual['mci_id']))
+
+        assert response.status_code == 200
+        assert response.json
+    
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_post_user_existing(self, mocker, database, individual, test_client, json_headers):
+        '''
+        Tests that POSTing an existing user returns a 200 with correct user information.
+        '''        
+        new_individual = self._post_new_individual(individual, test_client, json_headers)
+
+        with requests_mock.Mocker() as m:
+            m.post("http://mcimatchingservice_mci_1:8000/compute-match",
+                  json={"mci_id": new_individual['mci_id'], "score": 10.0}, status_code=201)
+
+            response = test_client.post('/users', data=json.dumps(individual), headers=json_headers)
+
+        assert response.status_code == 200
+        assert response.json['first_name'] == individual['first_name']
+        assert response.json['last_name'] == individual['last_name']
+        assert response.json['mci_id'] == new_individual['mci_id']
+        assert response.json['match_probability'] == 10.0
+
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_post_user_bad_json(self, individual, test_client, json_headers):
+        with requests_mock.Mocker() as m:
+            m.post("http://mcimatchingservice_mci_1:8000/compute-match",
+                  json={"mci_id": "", "score": ""}, status_code=201)
+
+            bad_json = {
+                'first_name': "Single",
+                'middle_name': "Quote",
+                'last_name': "Mistake",
+            }
+
+            response = test_client.post('/users', data=bad_json, headers=json_headers)
+            assert response.status_code == 400
+            assert response.json['error'] == 'Malformed or empty JSON object found in request body.'
+
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_post_user_matching_down(self, mocker, individual, test_client, json_headers):
         response = test_client.post('/users', data=json.dumps(individual), headers=json_headers)
 
         assert response.status_code == 400

--- a/tests/test_user_endpoints.py
+++ b/tests/test_user_endpoints.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+import mock
 import requests_mock
 from expects import be, be_above, expect, have_keys
 
@@ -8,19 +9,22 @@ from mci import app
 from mci_database import db
 from mci_database.db.models import Individual
 
-
 class TestMCIAPI(object):
-    def test_users_endpoint(self, mocker, database, individual, test_client, json_headers):
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_users_endpoint_empty(self, mocker, database, individual, test_client, json_headers):
         '''
-        Tests that the users endpoint returns expected content when the database has Individual entries.
+        Tests that the users endpoint returns expected content when the database is empty.
         '''
-        mocker.patch(
-            'brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
         response = test_client.get('/users')
 
         assert response.status_code == 404
         assert response.json['users'] == []
-        
+    
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_users_endpoint_populated(self, mocker, database, individual, test_client, json_headers):
+        '''
+        Tests that the users endpoint returns expected content when the database has Individual entries.
+        '''
         self._post_new_individual(individual, test_client, json_headers)
 
         response = test_client.get('/users')
@@ -29,25 +33,22 @@ class TestMCIAPI(object):
         assert isinstance(response.json['users'][0], dict)
         assert 'mci_id' in response.json['users'][0].keys()
 
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
     def test_get_user_invalid(self, mocker, database, test_client):
         '''
         Tests that GETing an invalid user returns the correct error message.
         '''
-        mocker.patch(
-            'brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
         response = test_client.get('/users/123badid')
 
         assert response.status_code == 410
         assert response.json['message']
         assert response.json['message'] == 'An individual with that ID does not exist in the MCI.'
     
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
     def test_get_user_valid(self, mocker, database, individual, test_client, json_headers):
         '''
         Tests that GETing a valid user returns the JSON and 200 status code.
         '''
-        mocker.patch(
-            'brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-
         new_individual = self._post_new_individual(individual, test_client, json_headers)
 
         response = test_client.get('/users/{}'.format(new_individual['mci_id']))
@@ -55,26 +56,35 @@ class TestMCIAPI(object):
         assert response.status_code == 200
         assert response.json
     
-    def test_remove_pii_invalid_id(self, mocker, database, individual, test_client, json_headers):
-        mocker.patch(
-            'brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_post_existing_user(self, mocker, database, individual, test_client, json_headers):
+        '''
+        Tests that POSTing an existing user returns a 200 with correct user information.
+        '''        
+        new_individual = self._post_new_individual(individual, test_client, json_headers)
 
+        with requests_mock.Mocker() as m:
+            m.post("http://mcimatchingservice_mci_1:8000/compute-match",
+                  json={"mci_id": new_individual['mci_id'], "score": 10.0}, status_code=201)
+
+            response = test_client.post('/users', data=json.dumps(individual), headers=json_headers)
+
+        assert response.status_code == 200
+        assert response.json['first_name'] == individual['first_name']
+        assert response.json['last_name'] == individual['last_name']
+        assert response.json['mci_id'] == new_individual['mci_id']
+        assert response.json['match_probability'] == 10.0
+
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_remove_pii_invalid_id(self, mocker, database, individual, test_client, json_headers):
         response = test_client.post(
             '/users/remove-pii', data=json.dumps({"mci_id": "123fakeid"}), headers=json_headers)
         
         assert response.status_code == 410
         assert response.json['message'] == 'An individual with that ID does not exist in the MCI.'
     
-    def test_remove_pii_valid_id(self, 
-                                 mocker, 
-                                 database, 
-                                 individual, 
-                                 test_client, 
-                                 json_headers,
-                                 app_configured):
-        mocker.patch(
-            'brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-
+    @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
+    def test_remove_pii_valid_id(self, mocker, app_configured, database, individual, test_client, json_headers):
         new_individual = self._post_new_individual(individual, test_client, json_headers)
         
         with app_configured.app_context():
@@ -95,7 +105,6 @@ class TestMCIAPI(object):
             assert updated_individual.email_address == None
             assert updated_individual.telephone == None
             assert updated_individual.ssn == None
-        
 
     def _post_new_individual(self, individual, test_client, headers):
         '''

--- a/tests/test_user_endpoints.py
+++ b/tests/test_user_endpoints.py
@@ -57,7 +57,7 @@ class TestMCIAPI(object):
         assert response.json
     
     @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_post_user_existing(self, mocker, database, individual, test_client, json_headers):
+    def test_post_users_existing(self, mocker, database, individual, test_client, json_headers):
         '''
         Tests that POSTing an existing user returns a 200 with correct user information.
         '''        
@@ -76,7 +76,7 @@ class TestMCIAPI(object):
         assert response.json['match_probability'] == 10.0
 
     @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_post_user_bad_json(self, individual, test_client, json_headers):
+    def test_post_users_bad_json(self, individual, test_client, json_headers):
         with requests_mock.Mocker() as m:
             m.post("http://mcimatchingservice_mci_1:8000/compute-match",
                   json={"mci_id": "", "score": ""}, status_code=201)
@@ -92,7 +92,7 @@ class TestMCIAPI(object):
             assert response.json['error'] == 'Malformed or empty JSON object found in request body.'
 
     @mock.patch('brighthive_authlib.providers.AuthZeroProvider.validate_token', return_value=True)
-    def test_post_user_matching_down(self, mocker, individual, test_client, json_headers):
+    def test_post_users_matching_down(self, mocker, individual, test_client, json_headers):
         response = test_client.post('/users', data=json.dumps(individual), headers=json_headers)
 
         assert response.status_code == 400


### PR DESCRIPTION
# Overview

This PR updates the tests for User endpoints. The cases currently tested:

* GETing the `users` endpoint behaves as expected when: 
    1. the database is empty
    2. the database has an Individual;
* GETing the `user` endpoint behaves as expected when:
    1. using an invalid mci_id
    2. using a valid mci_id;
* POSTing to the `users` endpoint behaves as expected when: 
    1. POSTing a new user with valid json
    2. POSTing an existing user
    3. POSTing with bad json
    4. POSTing with the 
* POSTing to the `remove-pii` endpoint behaves as expected when:
    1. providing an invalid mci_id
    2. providing a valid mci_id (and hence deleting PII)

@gregmundy - I am going to write additional tests for the "helper" functions in another PR.