### PR TITLE
task: Return 200 when users table does not have records

### DIFF
--- a/mci/api/v1_0_0/user_handler.py
+++ b/mci/api/v1_0_0/user_handler.py
@@ -210,7 +210,6 @@ class UserHandler(object):
             links = build_links('users', offset, limit, row_count)
         else:
             links = []
-            status_code = 404
 
         response = OrderedDict()
         response['users'] = []


### PR DESCRIPTION
Closes #27 

This PR adjusts the response status for the `users` endpoint: if the users resource does not have records, then it should return a 200, not a 404.

Why? Mostly, because the users endpoint should behave like the other endpoints, all of which return an empty list and a 200 status code, [e.g., `education_levels](https://github.com/brighthive/master-client-index/blob/master/mci/api/v1_0_0/helper_handler.py#L28-L38). 